### PR TITLE
feat: use last index to compare new cards against

### DIFF
--- a/packages/maumau-server/src/game/rules.ts
+++ b/packages/maumau-server/src/game/rules.ts
@@ -7,16 +7,16 @@ const rules: Record<ActionType, Rule> = {
   PLAY_REGULAR_CARD: ({ players, playersTurnIndex, pendingSevens, stack, nextSuit }) =>
     !pendingSevens &&
     players[playersTurnIndex].hasCard(
-      (card) => card.isRegular() && card.doesMatch(stack[0]) && card.matchesNextSuit(nextSuit),
+      (card) => card.isRegular() && card.doesMatch(stack[stack.length - 1]) && card.matchesNextSuit(nextSuit),
     ),
   PLAY_EIGHT: ({ players, playersTurnIndex, pendingSevens, stack, nextSuit }) =>
     !pendingSevens &&
     players[playersTurnIndex].hasCard(
-      (card) => card.isEight() && card.doesMatch(stack[0]) && card.matchesNextSuit(nextSuit),
+      (card) => card.isEight() && card.doesMatch(stack[stack.length - 1]) && card.matchesNextSuit(nextSuit),
     ),
   PLAY_SEVEN: ({ players, playersTurnIndex, pendingSevens, stack, nextSuit }) =>
     players[playersTurnIndex].hasCard(
-      (card) => card.isSeven() && card.doesMatch(stack[0]) && card.matchesNextSuit(nextSuit),
+      (card) => card.isSeven() && card.doesMatch(stack[stack.length - 1]) && card.matchesNextSuit(nextSuit),
     ),
   PLAY_JACK: ({ players, playersTurnIndex, pendingSevens }) =>
     !pendingSevens && players[playersTurnIndex].hasCard((card) => card.isJack()),


### PR DESCRIPTION
Since new cards are added to the end of the stack array we need to compare new cards against the last card in the stack instead of the first one.

Also, cards are drawn from the beginning of the stack for 
- KANNET_AND_DRAW https://github.com/emanuelschmitt/maumau/blob/master/packages/maumau-server/src/game/reducer.ts#L106
- ACCEPT_PENDING_SEVENS: https://github.com/emanuelschmitt/maumau/blob/master/packages/maumau-server/src/game/reducer.ts#L137